### PR TITLE
Add basic pipeline to build images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+elifePipeline {
+    def commit
+    DockerImage image
+    stage 'Checkout', {
+        checkout scm
+        commit = elifeGitRevision()
+    }
+
+    node('containers-jenkins-plugin') {
+        stage 'Build images', {
+            checkout scm
+            dockerComposeBuild(commit)
+        }
+
+        stage 'Project tests', {
+            //dockerComposeProjectTests('digests', commit, ['/srv/digests/build/*.xml'])
+            //dockerComposeSmokeTests(commit, [
+            //    'scripts': [
+            //        'wsgi': './smoke_tests_wsgi.sh',
+            //    ],
+            //])
+        }
+
+        elifeMainlineOnly {
+            stage 'Push image', {
+                image = DockerImage.elifesciences(this, "digests", commit)
+                image.push()
+            }
+        }
+    }
+
+
+    elifeMainlineOnly {
+        stage 'Approval', {
+            elifeGitMoveToBranch commit, 'approved'
+            node('containers-jenkins-plugin') {
+                image = DockerImage.elifesciences(this, "digests", commit)
+                image.pull()
+                image.tag('approved').push()
+            }
+        }
+    }
+}
+

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,3 @@
+version: '3'
+
+services:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,3 +1,3 @@
 version: '3'
 
-services:
+services: {}


### PR DESCRIPTION
For elifesciences/jira-import#4292, builds images, and pushes them if on the mainline (but not on PRs).