### PR TITLE
Push latest image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ elifePipeline {
                 image = DockerImage.elifesciences(this, "digests", commit)
                 image.pull()
                 image.tag('approved').push()
+                image.tag('latest').push()
             }
         }
     }


### PR DESCRIPTION
This should be done upon deployment in production. However there is no production environment yet, and the Vagrant instance by default will use the `latest` tag.