### PR TITLE
Add custom renderers

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -75,8 +75,13 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 20,
     'DEFAULT_PARSER_CLASSES': (
+        'digests.parsers.DigestParser',
         'rest_framework.parsers.JSONParser',
-        'digests.parsers.DigestsParser',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'digests.renderers.DigestRenderer',
+        'digests.renderers.DigestsRenderer',
+        'rest_framework.renderers.JSONRenderer',
     )
 }
 

--- a/app/digests/models.py
+++ b/app/digests/models.py
@@ -26,7 +26,7 @@ class Digest(models.Model):
     updated = models.DateTimeField(null=True)
 
     class Meta:
-        ordering = ('published',)
+        ordering = ('stage', '-published',)
 
     def __str__(self):
         return f'{self.id}: {self.title}'

--- a/app/digests/models.py
+++ b/app/digests/models.py
@@ -26,7 +26,7 @@ class Digest(models.Model):
     updated = models.DateTimeField(null=True)
 
     class Meta:
-        ordering = ('stage', '-published',)
+        ordering = ('-published',)
 
     def __str__(self):
         return f'{self.id}: {self.title}'

--- a/app/digests/models.py
+++ b/app/digests/models.py
@@ -25,5 +25,8 @@ class Digest(models.Model):
     title = models.CharField(max_length=255)
     updated = models.DateTimeField(null=True)
 
+    class Meta:
+        ordering = ('published',)
+
     def __str__(self):
         return f'{self.id}: {self.title}'

--- a/app/digests/parsers.py
+++ b/app/digests/parsers.py
@@ -2,5 +2,5 @@ from django.conf import settings
 from rest_framework.parsers import JSONParser
 
 
-class DigestsParser(JSONParser):
+class DigestParser(JSONParser):
     media_type = settings.DIGEST_CONTENT_TYPE

--- a/app/digests/renderers.py
+++ b/app/digests/renderers.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from rest_framework.renderers import JSONRenderer
+
+
+class DigestRenderer(JSONRenderer):
+    media_type = settings.DIGEST_CONTENT_TYPE
+
+
+class DigestsRenderer(JSONRenderer):
+    media_type = settings.DIGESTS_CONTENT_TYPE

--- a/app/digests/tests/test_digest_api.py
+++ b/app/digests/tests/test_digest_api.py
@@ -76,7 +76,7 @@ def test_is_ordered_by_descending_published_date(client: Client, digest: Digest,
 
     response = client.get(DIGESTS_URL, **{'ACCEPT': settings.DIGESTS_CONTENT_TYPE})
     assert response.status_code == 200
-
+    assert len(response.data['items']) == 2
     # check most recently published digest is first
     assert response.data['items'][0]['id'] == '10'
     assert response.data['items'][0]['published'] == new_pub_date

--- a/app/digests/tests/test_digest_api.py
+++ b/app/digests/tests/test_digest_api.py
@@ -14,7 +14,7 @@ DIGESTS_URL = '/digests'
 
 @pytest.mark.django_db
 def test_can_get_digest(client: Client):
-    response = client.get(DIGESTS_URL)
+    response = client.get(DIGESTS_URL, **{'ACCEPT': settings.DIGESTS_CONTENT_TYPE})
     assert response.status_code == 200
 
 
@@ -25,7 +25,7 @@ def test_has_expected_data_in_response(client: Client,
                                        digest_content_json: List[Dict],
                                        digest_related_content_json: List[Dict],
                                        digest_subjects_json: List[Dict]):
-    response = client.get(DIGESTS_URL)
+    response = client.get(DIGESTS_URL, **{'ACCEPT': settings.DIGESTS_CONTENT_TYPE})
     data = response.data['items'][0]
     assert response.data['total'] == 1
     assert len(response.data['items']) == 1
@@ -43,14 +43,14 @@ def test_has_expected_data_in_response(client: Client,
 def test_can_get_digest_by_id(client: Client,
                               digest: Digest,
                               digest_json: Dict):
-    response = client.get(f'{DIGESTS_URL}/{digest.id}')
+    response = client.get(f'{DIGESTS_URL}/{digest.id}', **{'ACCEPT': settings.DIGEST_CONTENT_TYPE})
     assert response.data == digest_json
     assert response.content_type == settings.DIGEST_CONTENT_TYPE
 
 
 @pytest.mark.django_db
-def test_has_digest_content_type_header(client: Client):
-    response = client.get(DIGESTS_URL)
+def test_has_digests_content_type_header(client: Client):
+    response = client.get(DIGESTS_URL, **{'ACCEPT': settings.DIGESTS_CONTENT_TYPE})
     assert response.status_code == 200
     assert response.content_type == settings.DIGESTS_CONTENT_TYPE
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
         image: postgres:9.4
         volumes:
             - ./config/application_user.sql:/docker-entrypoint-initdb.d/application_user.sql
+        ports:
+            - '5432:5432'
         env_file:
             - dev.env
     goaws:


### PR DESCRIPTION
Allows handling of `Accept` headers using custom content types and adds default ordering:

`stage` -> `-published`