### PR TITLE
Wait on db through Django

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+config/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/logs/
 /var/
 __pycache__/
 .pytest_cache/

--- a/migrate.sh
+++ b/migrate.sh
@@ -2,6 +2,7 @@
 
 source venv/bin/activate
 
-until echo > /dev/tcp/$POSTGRES_HOST/5432; do sleep 1; done
+#until echo > /dev/tcp/$POSTGRES_HOST/5432; do sleep 1; done
+until python app/manage.py inspectdb; do sleep 1; done
 
 python app/manage.py migrate


### PR DESCRIPTION
Relies on the \`DATABASE_URL\` variable containing all database parameters, rather than on the \`POSTGRES_HOST\` which should only be available to the \`postgres\` container (and that would have to be changed for RDS with a custom remote hostname).

Works as before, but produces some exceptions before wsgi finally starts:
```
wsgi_1   | django.db.utils.OperationalError: could not connect to server: Connection refused
wsgi_1   |      Is the server running on host "db" (192.168.16.3) and accepting
wsgi_1   |      TCP/IP connections on port 5432?
```
Is there a way to gracefully fail in those?