### PR TITLE
Add filtering by relatedContent/article id

### DIFF
--- a/app/digests/api.py
+++ b/app/digests/api.py
@@ -48,13 +48,20 @@ class DigestViewSet(viewsets.ModelViewSet):
 
     @staticmethod
     def _filter_by_related_content_id(qs: QuerySet, content_id: str) -> QuerySet:
-        """Will filter by the first `relatedContent` `id` value if present.
+        """Will filter by `relatedContent` `id` value if present.
 
         :param qs: class: `QuerySet`
         :param content_id: str
         :return: class: `QuerySet`
         """
-        return qs.filter(relatedContent__0__id=content_id)
+        return qs.filter(
+            relatedContent__contains=[
+                {
+                    'id': content_id,
+                    'type': 'research-article'
+                }
+            ]
+        )
 
     @staticmethod
     def _publish_event(instance: Digest) -> None:

--- a/app/digests/tests/conftest.py
+++ b/app/digests/tests/conftest.py
@@ -174,6 +174,41 @@ def digest_related_content_json() -> List[Dict]:
 
 
 @pytest.fixture(scope='session')
+def multiple_related_content_json() -> List[Dict]:
+    return [
+        {
+            "type": "tools-resources",
+            "status": "vor",
+            "id": "34408",
+            "version": 1,
+            "doi": "10.7554/eLife.34408",
+            "authorLine": "Some author",
+            "title": "Some title",
+            "stage": "published",
+            "published": "2018-05-30T00:00:00Z",
+            "statusDate": "2018-05-30T00:00:00Z",
+            "volume": 7,
+            "elocationId": "e34408"
+        },
+        {
+            "type": "research-article",
+            "status": "vor",
+            "id": "33286",
+            "version": 1,
+            "doi": "10.7554/eLife.33286",
+            "authorLine": "Yue Zhou et al.",
+            "title": "Biosynthetic tailoring of existing ascaroside pheromones "
+                     "alters their biological function in <i>C. elegans</i>",
+            "stage": "published",
+            "published": "2018-06-04T00:00:00Z",
+            "statusDate": "2018-06-04T00:00:00Z",
+            "volume": 7,
+            "elocationId": "e33286"
+        }
+    ]
+
+
+@pytest.fixture(scope='session')
 def digest_subjects_json() -> List[Dict]:
     return [
         {

--- a/app/digests/tests/test_digest_api_filtering.py
+++ b/app/digests/tests/test_digest_api_filtering.py
@@ -1,0 +1,36 @@
+from typing import Dict
+
+from django.conf import settings
+from django.test.client import Client
+import pytest
+
+from digests.models import Digest
+
+DIGESTS_URL = '/digests'
+
+
+@pytest.mark.django_db
+def test_can_filter_by_article_id(can_preview_header: Dict,
+                                  client: Client,
+                                  preview_digest: Digest,
+                                  digest_json: Dict,
+                                  digest_related_content_json: Dict):
+    article_id = digest_related_content_json[0]['id']
+    response = client.get(f'{DIGESTS_URL}?article={article_id}',
+                          **{'ACCEPT': settings.DIGEST_CONTENT_TYPE},
+                          **can_preview_header)
+    assert response.data['total'] == 1
+    assert response.data['items'][0]['id'] == preview_digest.id
+    assert response.data['items'][0]['relatedContent'][0]['id'] == article_id
+
+
+@pytest.mark.django_db
+def test_will_return_empty_if_article_id_not_found(can_preview_header: Dict,
+                                                   client: Client,
+                                                   preview_digest: Digest,
+                                                   digest_json: Dict):
+    article_id = '123456'
+    response = client.get(f'{DIGESTS_URL}?article={article_id}',
+                          **{'ACCEPT': settings.DIGEST_CONTENT_TYPE},
+                          **can_preview_header)
+    assert response.data['total'] == 0

--- a/app/digests/tests/test_digest_api_filtering.py
+++ b/app/digests/tests/test_digest_api_filtering.py
@@ -34,3 +34,20 @@ def test_will_return_empty_if_article_id_not_found(can_preview_header: Dict,
                           **{'ACCEPT': settings.DIGEST_CONTENT_TYPE},
                           **can_preview_header)
     assert response.data['total'] == 0
+
+
+@pytest.mark.django_db
+def test_will_find_by_article_id_if_not_first_item(can_preview_header: Dict,
+                                                   client: Client,
+                                                   preview_digest: Digest,
+                                                   multiple_related_content_json: Dict):
+    preview_digest.relatedContent = multiple_related_content_json
+    preview_digest.save()
+
+    article_id = multiple_related_content_json[1]['id']
+    response = client.get(f'{DIGESTS_URL}?article={article_id}',
+                          **{'ACCEPT': settings.DIGEST_CONTENT_TYPE},
+                          **can_preview_header)
+    assert response.data['total'] == 1
+    assert response.data['items'][0]['id'] == preview_digest.id
+    assert response.data['items'][0]['relatedContent'][1]['id'] == article_id


### PR DESCRIPTION
Addresses part of [#4370](https://github.com/elifesciences/issues/issues/4370).

Provides functionality to search for digests based on the `relatedContent` `id`, which is primarily article ids.

`relatedContent` is an array of objects and by design, the filter only checks the first entry's `id`.

I had tinkered with a custom filterset to handle this but hit some complications due the `relatedContent` field being a `JSONField`. It's possible to imeplment it in this way, I just ran out of time. If this is to be extended in the future then this would be the direction to go.

Usage:
You can use `GET /digests?article=12345` and if any digests first `relatedContent` entry has the `id` of `12345` then it will be included in the response. It can also be combined with the currently implemented `stage` filter if required.