### PR TITLE
PUT new digest failure with 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ For consistency of environment, use the `venv` container:
 docker-compose run venv pipenv install --dev uwsgi-tools
 docker-compose run venv pipenv lock
 ```
+
+## Run a test
+
+```
+docker-compose build
+docker-compose run wsgi venv/bin/pytest app/digests/tests/test_digest_api.py
+```
+
+Images currently have to be re-built for modifications to any part of the code to be noticed.

--- a/app/digests/api.py
+++ b/app/digests/api.py
@@ -118,17 +118,17 @@ class DigestViewSet(viewsets.ModelViewSet):
                 if patch:
                     # validation for `PATCH` request
                     instance = self.get_object()
-                    serializer = self.get_serializer(instance, data=request.data, partial=True)
                     existing_instance = self.get_serializer(instance)
                     new_data = dict(ChainMap(request.data, existing_instance.data))
+                    serializer = self.get_serializer(instance, data=request.data, partial=True)
                 else:
                     # validation for `PUT` request
+                    new_data = request.data
                     try:
                         instance = self.get_object()
                         serializer = self.get_serializer(instance, data=request.data)
                     except Http404 as e:
                         serializer = CreateDigestSerializer(data=request.data)
-                    new_data = request.data
 
                 self._validate_against_schema(request, data=new_data)
 

--- a/app/digests/api.py
+++ b/app/digests/api.py
@@ -138,7 +138,7 @@ class DigestViewSet(viewsets.ModelViewSet):
 
                 transaction.on_commit(lambda: self._publish_event(instance))
 
-            return Response(status=204)
+            return Response(serializer.data, status=204)
 
         except ValidationError as err:
             err.code = status.HTTP_400_BAD_REQUEST

--- a/app/digests/api.py
+++ b/app/digests/api.py
@@ -111,23 +111,23 @@ class DigestViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         try:
-            partial = kwargs.pop('partial', False)
+            patch = kwargs.pop('partial', False)
 
             with transaction.atomic():
 
-                if partial:
+                if patch:
                     # validation for `PATCH` request
                     instance = self.get_object()
-                    serializer = self.get_serializer(instance, data=request.data, partial=partial)
+                    serializer = self.get_serializer(instance, data=request.data, partial=True)
                     existing_instance = self.get_serializer(instance)
                     new_data = dict(ChainMap(request.data, existing_instance.data))
                 else:
+                    # validation for `PUT` request
                     try:
                         instance = self.get_object()
-                        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+                        serializer = self.get_serializer(instance, data=request.data)
                     except Http404 as e:
                         serializer = CreateDigestSerializer(data=request.data)
-                    # validation for `PUT` request
                     new_data = request.data
 
                 self._validate_against_schema(request, data=new_data)

--- a/app/digests/tests/test_digest_api.py
+++ b/app/digests/tests/test_digest_api.py
@@ -62,11 +62,18 @@ def test_has_digests_content_type_header(can_preview_header: Dict,
 
 
 @pytest.mark.django_db
-def test_can_ingest_digest(rest_client: APIClient, digest_json: Dict, can_edit_headers: Dict):
+def test_can_ingest_digest_post(rest_client: APIClient, digest_json: Dict, can_edit_headers: Dict):
     response = rest_client.post(DIGESTS_URL, data=json.dumps(digest_json),
                                 content_type=settings.DIGEST_CONTENT_TYPE,
                                 **can_edit_headers)
     assert response.status_code == 201
+
+@pytest.mark.django_db
+def test_can_ingest_digest_put(rest_client: APIClient, digest_json: Dict, can_edit_headers: Dict):
+    response = rest_client.put(f'{DIGESTS_URL}/{digest_json["id"]}', data=json.dumps(digest_json),
+                                content_type=settings.DIGEST_CONTENT_TYPE,
+                                **can_edit_headers)
+    assert response.status_code == 204
 
 
 @pytest.mark.django_db

--- a/app/digests/tests/test_digest_api_updates.py
+++ b/app/digests/tests/test_digest_api_updates.py
@@ -29,7 +29,7 @@ def test_can_update_digest_via_patch(key: str,
                                  data=json.dumps({key: value}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['id'] == '2'
     assert response.data[key] == value
     assert response.data['updated'] == '2018-01-01T00:00:00Z'
@@ -46,7 +46,7 @@ def test_wont_update_digest_id_via_patch(can_edit_headers: Dict,
                                  data=json.dumps({'id': new_id}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['id'] == preview_digest.id
 
 
@@ -63,7 +63,7 @@ def test_can_update_digest_content_via_patch(can_edit_headers: Dict,
                                  data=json.dumps({'content': new_content}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['content'][0]['text'] == new_text
 
 
@@ -80,7 +80,7 @@ def test_can_update_digest_related_content_via_patch(can_edit_headers: Dict,
                                  data=json.dumps({'relatedContent': new_content}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['relatedContent'][0]['title'] == new_text
 
 
@@ -97,7 +97,7 @@ def test_can_update_digest_subjects_via_patch(can_edit_headers: Dict,
                                  data=json.dumps({'subjects': new_subjects}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['subjects'][0]['name'] == new_name
 
 
@@ -114,7 +114,7 @@ def test_can_update_digest_image_via_patch(can_edit_headers: Dict,
                                  data=json.dumps({'image': new_image}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['image']['thumbnail']['alt'] == new_alt
 
 
@@ -153,7 +153,7 @@ def test_can_update_digest_via_put(can_edit_headers: Dict,
                                data=json.dumps(new_data),
                                content_type=settings.DIGEST_CONTENT_TYPE,
                                **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.data['title'] == 'New Title'
     assert response.data['stage'] == 'published'
     assert response.data['updated'] == '2018-01-01T00:00:00Z'

--- a/app/digests/tests/test_digest_api_updates.py
+++ b/app/digests/tests/test_digest_api_updates.py
@@ -22,6 +22,7 @@ DIGESTS_URL = '/digests'
 def test_can_update_digest_via_patch(key: str,
                                      value: str,
                                      can_edit_headers: Dict,
+                                     can_preview_header: Dict,
                                      preview_digest: Digest,
                                      digest_json: Dict,
                                      rest_client: APIClient):
@@ -30,9 +31,10 @@ def test_can_update_digest_via_patch(key: str,
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
     assert response.status_code == 204
-    assert response.data['id'] == '2'
-    assert response.data[key] == value
-    assert response.data['updated'] == '2018-01-01T00:00:00Z'
+    get_response = json.loads(rest_client.get(f'{DIGESTS_URL}/{preview_digest.id}', **can_preview_header).content)
+    assert get_response['id'] == '2'
+    assert get_response[key] == value
+    assert get_response['updated'] == '2018-01-01T00:00:00Z'
 
 
 @pytest.mark.django_db

--- a/app/digests/tests/test_digest_api_updates.py
+++ b/app/digests/tests/test_digest_api_updates.py
@@ -31,6 +31,8 @@ def test_can_update_digest_via_patch(key: str,
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
     assert response.status_code == 204
+    # TODO: extract in conftest.py and use across the 204-related tests
+    # to be able to remove the body
     get_response = json.loads(rest_client.get(f'{DIGESTS_URL}/{preview_digest.id}', **can_preview_header).content)
     assert get_response['id'] == '2'
     assert get_response[key] == value

--- a/app/digests/tests/test_events.py
+++ b/app/digests/tests/test_events.py
@@ -39,7 +39,7 @@ def test_can_send_event_when_patching_a_digest(event_publisher: MagicMock,
                                  data=json.dumps({'stage': 'published'}),
                                  content_type=settings.DIGEST_CONTENT_TYPE,
                                  **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert event_publisher.assert_called
     assert event_publisher.publish.call_args[0] == (
         {'id': digest_json['id'], 'type': 'digest'},
@@ -57,7 +57,7 @@ def test_can_send_event_when_updating_a_digest_via_put(event_publisher: MagicMoc
                                data=json.dumps(digest_json),
                                content_type=settings.DIGEST_CONTENT_TYPE,
                                **can_edit_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert event_publisher.assert_called
     assert event_publisher.publish.call_args[0] == (
         {'id': digest_json['id'], 'type': 'digest'},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
             #- goaws
             #- migrate
             - venv
+            - db
     db:
         image: postgres:9.4
         volumes:


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4450

This fixes the behavior, allowing PUT to happen for a new item.

It also changes the status code of PATCH/PUT to 204 to conform to the `api-raml` definition; it doesn't yet remove the body from the response as it has lots of implications for current tests which would have to issue a new `GET` to check the result.

PATCH and POST are still in place, [their removal later](https://github.com/elifesciences/issues/issues/4441) will make the `update` action simpler.