### PR TITLE
Pipfile.lock from bus-sdk-python upgraded to 0.0.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ elife-api-validator = {git = "https://github.com/elifesciences/api-validator-pyt
 uwsgi = "*"
 dj-database-url = "*"
 "psycopg2-binary" = "*"
-djangorestframework = "==3.10.3"
+djangorestframework = "*"
 uwsgi-tools = "*"
 jsonschema = "*"
 elife-bus-sdk = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b3d7229c2e20fcb582d349d8002662cce3ca1a5022fc31cb3ca37cebc4c23b01"
+            "sha256": "732a440050fd0925217dfd742ddef2a200000c88305d77fe6ef69af44fc40d29"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -63,11 +63,11 @@
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:5488aed8f8df5ec1d70f04b2114abc52ae6729748a176c453313834a9ee179c8",
-                "sha256:dc81cbf9775c6898a580f6f1f387c4777d12bd87abf0f5406018d32ccae71090"
+                "sha256:05809fc66e1c997fd9a32ea5730d9f4ba28b109b9da71fccfa5ff241201fd0a4",
+                "sha256:e782087823c47a26826ee5b6fa0c542968219263fb3976ec3c31edab23a4001f"
             ],
             "index": "pypi",
-            "version": "==3.10.3"
+            "version": "==3.11.0"
         },
         "docutils": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,17 +25,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:38057b066990172ce6ebbf2a5e046a545503793581fcf14cab0e3821c6112eb0",
-                "sha256:f79f77dca2280f7780f39d72a5088f4cf2b626c0921e7185ed6ac17abfdd7e6c"
+                "sha256:0542e1e7e2ed8a7b0d3d1b513ec2252328df7eab351d0642677dd72126826948",
+                "sha256:65561a89339d8cc265a048560381b6771f9a06f4224e7741d0dc01808f5ba28f"
             ],
-            "version": "==1.4.7"
+            "version": "==1.12.10"
         },
         "botocore": {
             "hashes": [
-                "sha256:19d519c8b37d7d35334267f25515e395c431a12a3c624214e2267d12950dbe95",
-                "sha256:5c1c023075269265f44a1c5b09a18d6865eca1c85a4be6886ddcc8af01b1c997"
+                "sha256:2a1c043a21d66073e2de5375f3a22ddc2d27746b849b350a1430eea80aef2752",
+                "sha256:7354b6cee534dfad3c6d979c454f7a7b8c41fd5ac3ecf72e6b4578a49b31eee5"
             ],
-            "version": "==1.7.48"
+            "version": "==1.15.10"
         },
         "dj-database-url": {
             "hashes": [
@@ -71,10 +71,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
-                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "version": "==0.16"
+            "version": "==0.15.2"
         },
         "elife-api-validator": {
             "git": "https://github.com/elifesciences/api-validator-python.git",
@@ -82,11 +83,11 @@
         },
         "elife-bus-sdk": {
             "hashes": [
-                "sha256:1160d0c16ab6918bfca0540bfa84c695387b33a1840f1eb6386b9935eb46b749",
-                "sha256:36e8de94227d946775b249d02c112f5c869355bbfdb26c367300623934887004"
+                "sha256:3fee9d27122a4d71e8e1c31f69808aa9c9b47ba593800303fa814860e70b73ba",
+                "sha256:8c2ea4b9dc6bd9aff6b8d3851ef87fc056953b46b202e0d0b55106e1580bb21d"
             ],
             "index": "pypi",
-            "version": "==0.0.6"
+            "version": "==0.0.7"
         },
         "importlib-metadata": {
             "hashes": [
@@ -98,10 +99,10 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
-                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
+                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
             ],
-            "version": "==0.9.4"
+            "version": "==0.9.5"
         },
         "jsonschema": {
             "hashes": [
@@ -113,10 +114,10 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:0e651f2ff48dd1fc538fc1297892cf726d1ad4fc0b2578aae6a47f10f16afb2c"
+                "sha256:9228556dc93bd02d9164e3755f971c2ffba45ad2d8a9b6620f630a6d475421fc"
             ],
             "index": "pypi",
-            "version": "==5.4.1.134"
+            "version": "==5.8.0.136"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -185,10 +186,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
-                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
             ],
-            "version": "==0.1.13"
+            "version": "==0.3.3"
         },
         "six": {
             "hashes": [
@@ -203,6 +204,14 @@
                 "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
             "version": "==0.3.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.25.8"
         },
         "uwsgi": {
             "hashes": [
@@ -221,10 +230,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
-                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
             ],
-            "version": "==2.2.0"
+            "version": "==3.0.0"
         }
     },
     "develop": {
@@ -251,10 +260,10 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:10336fc80a235847c64033f9727f3847f37db4bd549be1d9f3b5ae0279256c69",
-                "sha256:6262de2f4bab671f7189bb8a0b9d8751da69a53f0b9813fb8f412681662d872a"
+                "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2",
+                "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"
             ],
-            "version": "==0.3.14"
+            "version": "==0.3.15"
         },
         "importlib-metadata": {
             "hashes": [
@@ -328,7 +337,9 @@
         "proofreader": {
             "hashes": [
                 "sha256:6c73d0589d4aed120df17303b189238a9ed15cf927ac190ed6cebb3151341c0d",
-                "sha256:a2173700ec564eb2bc3ef1345833cd2cb2b563952054e14adca23de230a57153"
+                "sha256:9293fb12a76c258161edae89bb4b3619ab144a853dc2ed7ef29ae30b97a3dba9",
+                "sha256:a2173700ec564eb2bc3ef1345833cd2cb2b563952054e14adca23de230a57153",
+                "sha256:bbd03ec023a5a5d310eb1d4e3bb86ebb25bca893401d52f481f7c1f5b8f17c6a"
             ],
             "index": "pypi",
             "version": "==0.0.8"
@@ -370,11 +381,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:9f8d44f4722b3d06b41afaeb8d177cfbe0700f8351b1fc755dd27eedaa3eb9e0",
-                "sha256:f5d3d0e07333119fe7d4af4ce122362dc4053cdd34a71d2766290cf5369c64ad"
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
             ],
             "index": "pypi",
-            "version": "==5.3.3"
+            "version": "==5.3.5"
         },
         "pytest-django": {
             "hashes": [
@@ -386,11 +397,11 @@
         },
         "pytest-freezegun": {
             "hashes": [
-                "sha256:94c370a2cd3db9692962522cb74525d908e669df7cb53a448e01bb47c21a8173",
-                "sha256:b86b13ef75959bedf4c32f1fd81fec66fa4502d9892e0ef6ad1717a34fe1560e"
+                "sha256:060cdf192848e50a4a681a5e73f8b544c4ee5ebc1fab3cb7223a0097bac2f83f",
+                "sha256:1c77b2917883b8abf817fc39a1fd3f40ac43711eb923512abe7b6557e55eaaf1"
             ],
             "index": "pypi",
-            "version": "==0.3.0.post1"
+            "version": "==0.4.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -415,16 +426,16 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:0ec40d9fd4ec9f9e3ff9bdd12dbd3535f4085949f4db93025089d7a673ea94e8"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.0"
         },
         "zipp": {
             "hashes": [
-                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
-                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
             ],
-            "version": "==2.2.0"
+            "version": "==3.0.0"
         }
     }
 }

--- a/app/digests/api.py
+++ b/app/digests/api.py
@@ -33,7 +33,7 @@ class DigestViewSet(viewsets.ModelViewSet):
     serializer_class = DigestSerializer
     pagination_class = DigestPagination
     filter_backends = (DjangoFilterBackend, )
-    filter_fields = ('stage',)
+    filterset_fields = ('stage',)
 
     content_type = settings.DIGEST_CONTENT_TYPE
     list_content_type = settings.DIGESTS_CONTENT_TYPE

--- a/app/digests/urls.py
+++ b/app/digests/urls.py
@@ -6,7 +6,7 @@ from digests.api import DigestViewSet
 
 
 router_v1 = routers.DefaultRouter(trailing_slash=False)
-router_v1.register('digests', DigestViewSet, base_name='digests')
+router_v1.register('digests', DigestViewSet, basename='digests')
 
 
 urlpatterns = [

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 junit_family = xunit1
-cache_dir = ../build/pytest
+# deactivate cacheprovider, which cannot create cache path on read-only Docker containers
+addopts = -p no:cacheprovider
 DJANGO_SETTINGS_MODULE = core.settings

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+junit_family = xunit1
 cache_dir = ../build/pytest
 DJANGO_SETTINGS_MODULE = core.settings


### PR DESCRIPTION
~~Work in progress to reduce warnings, I am opening this PR to see test results.~~

Re issue https://github.com/elifesciences/issues/issues/4506 to reduce warnings.

Changes include:
- `Pipfile.lock` is updated
- a couple changes to Django REST framework code to get rid of deprecation warnings
- changes to pytest running to remove warnings and probably using the `cacheprovider` plugin

When I was looking through some of the recent commits, I noticed @lsh-0 you may have had to downgrade `djangorestframework` pinning it to an earlier version due to the tests not passing. I think (maybe) with these changes I made to things that were raising deprecation warnings, this project may be compatible with the more recent release of it. Tests are running now to see. Did you want to pin the version anyway?