### PR TITLE
Log uwsgi to stdout

### DIFF
--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -7,7 +7,7 @@ wsgi-file =/srv/digests/app/core/wsgi.py
 callable = APP
 
 socket = 0.0.0.0:9000
-logto = /srv/digests/var/logs/uwsgi.log
+logto = /dev/stdout
 master=True
 processes=4
 vacuum=True


### PR DESCRIPTION
This actually causes the following warning messages:

> wsgi-1  | uwsgi_check_logrotate()/lseek(): Illegal seek [core/logging.c line 494]